### PR TITLE
Fixed spelling error in package name

### DIFF
--- a/packages/gatsby-plugin-extract-image-colors/README.md
+++ b/packages/gatsby-plugin-extract-image-colors/README.md
@@ -7,7 +7,9 @@
 
 ### Installation
 
-1. `npm i gatsby-plugin-extract-image-color`
+1. `npm i gatsby-plugin-extract-image-colors`
+    Or,
+    `yarn add gatsby-plugin-extract-image-colors`
 2. Add config to `gatsby-config.js`
 
 ```js
@@ -15,7 +17,7 @@
 module.exports = {
   plugins: [
     //... Other plugins
-    'gatsby-plugin-extract-image-color'
+    'gatsby-plugin-extract-image-colors'
   ]
 }
 ```
@@ -27,7 +29,7 @@ module.exports = {
   plugins: [
     //... Other plugins
     {
-      resolve: 'gatsby-plugin-extract-image-color',
+      resolve: 'gatsby-plugin-extract-image-colors',
       options: {
         extensions: ['jpg', 'png']
       }


### PR DESCRIPTION
The package is hosted with the name `gatsby-plugin-extract-image-colors` on npm and yarn, but the README says `gatsby-plugin-extract-image-color`. Using the documented name was causing a 404 error on installation.